### PR TITLE
Update psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ dj-database-url==0.4.2
 gunicorn==19.6.0
 kombu==4.0.2
 postgres==2.2.1
-psycopg2==2.6.2
+psycopg2==2.7.4
 python-dateutil==2.6.0
 pytz==2016.10
 requests==2.12.4


### PR DESCRIPTION
psycopg2 2.7+ adds postgresql 10 compatibility

Installation of older versions fails with the following error:

```
Complete output from command python setup.py egg_info:
running egg_info
creating pip-egg-info/psycopg2.egg-info
writing pip-egg-info/psycopg2.egg-info/PKG-INFO
writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
Error: could not determine PostgreSQL version from '10.2'
``` 

Related - https://github.com/psycopg/psycopg2/issues/594#issuecomment-331172198